### PR TITLE
fix/ Implement date validation and formatting compatible with Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,26 +12,28 @@ Should work on most "standard" linux distro
 
 ## Usage
 
-### Setup in two steps
+### Setup in three simple steps
 * Clone this repo (`git clone git@github.com:drawm/daily-notes.git`)
-* Move over to your own repo (you won't be able to push to https://github.com/drawm/daily-notes)
+* Create a separate repository to hold your notes because you won't be able to push to https://github.com/drawm/daily-notes)
+* Run setup script `note-setup`
+
+The setup script will ensure that your notes folder is properly created and will add a bunch of aliases to `$PATH`. This will allow you to manage your notes from any location in the terminal.
 
 ### Getting started
-When you start your day, use `begin` to update your notes, create a new note file.
-* All notes are located in the `notes/` folder.
+When you start your day, use `note-begin` to update your notes, create a new note file.
+
+* All notes are located in the `notes/` folder, relative to the root folder of your repository created in the setup.
 
 #### Examples:
 ```bash
 # Create a new note with the current date
-./note-begin
+note-begin
 
-# Create a new note for next friday
-./note-begin 'next friday'
-```
+# Create a note for a specific date
+note-begin 2022-04-21
 
-When you are done taking notes for the day, use `end` to save your notes and extract some sections for the next day.
-```bash
-./note-end
+# When you are done taking notes for the day, use the `note-end` alias to save your notes and extract some sections for the next day.
+note-end
 ```
 
 ### Sections
@@ -66,18 +68,18 @@ Keep
 For safe keeping
 ```
 
-Sections are saved when you use `./note-end` to complete your notes for the day.
+Sections are saved when you use `note-end` to complete your notes for the day.
 
 ### Useful tips
-* To quickly open yesterday's note, simply run `./note-yesterday`
-* Same goes for tomorrow's note, simply run `./note-tomorrow`
-* To create a note without updating or syncing your files, use `./note-new` 
-* To open a note without creating a new file and adding sections to it, use `./note-open`
+* To quickly open yesterday's note, simply run `note-yesterday`
+* Same goes for tomorrow's note, simply run `note-tomorrow`
+* To create a note without updating or syncing your files, use `note-new` 
+* To open a note without creating a new file and adding sections to it, use `note-open`
 * All scripts that open notes accept a date as an argument to open the note file of that day.
-    * `./note-open 'today'` (same as `./note-open`)
-    * `./note-new 'last tuesday'`
-    * `./note-tomorrow 'last sunday'` (kinda dumb but it works :shrug:)
-    * `./note-yesterday 'next monday'` (kinda dumb but it works :shrug:)
+    * `note-open 'today'` (same as `./note-open`)
+    * `note-new 'last tuesday'`
+    * `note-tomorrow 'last sunday'` (kinda dumb but it works :shrug:)
+    * `note-yesterday 'next monday'` (kinda dumb but it works :shrug:)
 
 ## Permissions
 This project need to be able to read and write files. For convenience, the `$HOME` environment variable is also needed.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ Sections are saved when you use `note-end` to complete your notes for the day.
 * All scripts that open notes accept a date as an argument to open the note file of that day.
     * `note-open 'today'` (same as `./note-open`)
     * `note-new 'last tuesday'`
-    * `note-tomorrow 'last sunday'` (kinda dumb but it works :shrug:)
-    * `note-yesterday 'next monday'` (kinda dumb but it works :shrug:)
 
 ## Permissions
 This project need to be able to read and write files. For convenience, the `$HOME` environment variable is also needed.

--- a/date-parser
+++ b/date-parser
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Used to check which machine we are running on
+unameOut="$(uname -s)"
+MAC_OS="Darwin"
+LINUX_OS="Linux"
+
+defaultDateFormat="%Y-%m-%d"
+
+# Since this script will be sourced, catch our potential positional argument here
+arg="${1}"
+
+parseInputDate() {
+    # Validate input date and format it
+    # Take into account different implementations of `date` commant
+    if [ "${unameOut}" = "${LINUX_OS}" ]
+    then
+        requiredDate="${arg:-today}"
+        formattedDate="$( date -d "${requiredDate}" +${defaultDateFormat})"
+    elif [ "${unameOut}" = "${MAC_OS}" ]
+    then
+        # On BSD based systems (i.e. Mac), date cannot accept any input as a string
+        # So we have to enforce a specific format to validate against
+        todaysDateMacOs="$(date -j +${defaultDateFormat})"
+        requiredDate="${arg:-${todaysDateMacOs}}"
+
+        validationResults="$(date -j -f "${defaultDateFormat}" "${requiredDate}" > /dev/null 2>&1)"
+
+        if [ "$?" = "1" ]
+        then
+            echo "Invalid date format ! Received: \"${requiredDate}\". Date should match: ${defaultDateFormat}"
+            exit 1
+        fi
+        # A bit more context on -f -> "-f input_fmt new_date +output_fmt"
+        # @see `man date` on BSD/Mac OS for more details
+        formattedDate="$(date -j -f "${defaultDateFormat}" ${requiredDate} +${defaultDateFormat})"
+    fi
+}
+
+# Expected argument, one of "today" | "tomorrow" | "yesterday"
+# Based on the underlying OS, use the correct implementation of `date`
+generateDate() {
+    if [ "${unameOut}" = "${MAC_OS}" ]
+    echo "I AM IN THE CASE"
+    then
+        case "${arg}" in
+        "tomorrow")
+            generatedDate="$(date -j -v+1d +${defaultDateFormat})"
+            ;;
+
+        "yesterday")
+            generatedDate="$(date -j -v-1d +${defaultDateFormat})"
+            ;;
+
+        *)
+            generatedDate="$(date -j +${defaultDateFormat})"
+            ;;
+        esac
+    elif [ "${1}" = "${LINUX_OS}" ]
+    then
+        case "${arg}" in
+        "tomorrow")
+            generatedDate="$( date --date="tomorrow" +${defaultDateFormat} )"
+            ;;
+
+        "yesterday")
+            generatedDate="$( date --date="yesterday" +${defaultDateFormat} )"
+            ;;
+
+        *)
+            generatedDate="$( date --date="today" +${defaultDateFormat} )"
+            ;;
+        esac
+    fi
+}
+
+

--- a/date-parser
+++ b/date-parser
@@ -1,29 +1,31 @@
 #!/bin/bash
 
-# Used to check which machine we are running on
-unameOut="$(uname -s)"
-MAC_OS="Darwin"
-LINUX_OS="Linux"
-
-defaultDateFormat="%Y-%m-%d"
-
 parseInputDate() {
-    dateToParse="${1}"
+    # Used to check which machine we are running on
+    local unameOut="$(uname -s)"
+    local MAC_OS="Darwin"
+    local LINUX_OS="Linux"
+
+    local defaultDateFormat="%Y-%m-%d"
+
+    local dateToParse="${1}"
     # Validate input date and format it
-    # Take into account different implementations of `date` commant
+    # Take into account different implementations of `date` command
     if [ "${unameOut}" = "${LINUX_OS}" ]
     then
-        requiredDate="${dateToParse:-today}"
-        formattedDate="$( date -d "${requiredDate}" +${defaultDateFormat})"
+        local requiredDate="${dateToParse:-today}"
+        echo "$( date -d "${requiredDate}" +${defaultDateFormat})"
+        return 0
     elif [ "${unameOut}" = "${MAC_OS}" ]
     then
         # On BSD based systems (i.e. Mac), date cannot accept any input as a string
         # So we have to enforce a specific format to validate against
-        todaysDateMacOs="$(date -j +${defaultDateFormat})"
-        requiredDate="${dateToParse:-${todaysDateMacOs}}"
+        local todaysDateMacOs="$(date -j +${defaultDateFormat})"
+        local requiredDate="${dateToParse:-${todaysDateMacOs}}"
 
-        validationResults="$(date -j -f "${defaultDateFormat}" "${requiredDate}" > /dev/null 2>&1)"
+        echo "$(date -j -f "${defaultDateFormat}" "${requiredDate}" > /dev/null 2>&1)"
 
+        # $? Will contain the return code of the last command
         if [ "$?" = "1" ]
         then
             echo "Invalid date format ! Received: \"${requiredDate}\". Date should match: ${defaultDateFormat}"
@@ -31,17 +33,28 @@ parseInputDate() {
         fi
         # A bit more context on -f -> "-f input_fmt new_date +output_fmt"
         # @see `man date` on BSD/Mac OS for more details
-        formattedDate="$(date -j -f "${defaultDateFormat}" ${requiredDate} +${defaultDateFormat})"
+        echo "$(date -j -f "${defaultDateFormat}" ${requiredDate} +${defaultDateFormat})"
+        return 0
     fi
+    echo "Unsupported platform '${unameOut}'"
+    return 1
 }
 
 # Expected argument, one of "today" | "tomorrow" | "yesterday"
 # Based on the underlying OS, use the correct implementation of `date`
 generateDate() {
-    requestedDate="${1}"
-    if [ "${requestedDate}" = "${MAC_OS}" ]
+    # Used to check which machine we are running on
+    local unameOut="$(uname -s)"
+    local MAC_OS="Darwin"
+    local LINUX_OS="Linux"
+
+    local defaultDateFormat="%Y-%m-%d"
+
+    local requestedDate="${1}"
+    local generatedDate=""
+    if [ "${unameOut}" = "${MAC_OS}" ]
     then
-        case "${c}" in
+        case "${requestedDate}" in
         "tomorrow")
             generatedDate="$(date -j -v+1d +${defaultDateFormat})"
             ;;
@@ -54,22 +67,11 @@ generateDate() {
             generatedDate="$(date -j +${defaultDateFormat})"
             ;;
         esac
-    elif [ "${requestedDate}" = "${LINUX_OS}" ]
+    elif [ "${unameOut}" = "${LINUX_OS}" ]
     then
-        case "${https://www.youtube.com/watch?v=qhN0tzN9zTA}" in
-        "tomorrow")
-            generatedDate="$( date --date="tomorrow" +${defaultDateFormat} )"
-            ;;
-
-        "yesterday")
-            generatedDate="$( date --date="yesterday" +${defaultDateFormat} )"
-            ;;
-
-        *)
-            generatedDate="$( date --date="today" +${defaultDateFormat} )"
-            ;;
-        esac
+        generatedDate="$( date --date="${requestedDate}" +${defaultDateFormat} )"
     fi
+    echo "${generatedDate}"
 }
 
 

--- a/date-parser
+++ b/date-parser
@@ -7,22 +7,20 @@ LINUX_OS="Linux"
 
 defaultDateFormat="%Y-%m-%d"
 
-# Since this script will be sourced, catch our potential positional argument here
-arg="${1}"
-
 parseInputDate() {
+    dateToParse="${1}"
     # Validate input date and format it
     # Take into account different implementations of `date` commant
     if [ "${unameOut}" = "${LINUX_OS}" ]
     then
-        requiredDate="${arg:-today}"
+        requiredDate="${dateToParse:-today}"
         formattedDate="$( date -d "${requiredDate}" +${defaultDateFormat})"
     elif [ "${unameOut}" = "${MAC_OS}" ]
     then
         # On BSD based systems (i.e. Mac), date cannot accept any input as a string
         # So we have to enforce a specific format to validate against
         todaysDateMacOs="$(date -j +${defaultDateFormat})"
-        requiredDate="${arg:-${todaysDateMacOs}}"
+        requiredDate="${dateToParse:-${todaysDateMacOs}}"
 
         validationResults="$(date -j -f "${defaultDateFormat}" "${requiredDate}" > /dev/null 2>&1)"
 
@@ -40,10 +38,10 @@ parseInputDate() {
 # Expected argument, one of "today" | "tomorrow" | "yesterday"
 # Based on the underlying OS, use the correct implementation of `date`
 generateDate() {
-    if [ "${unameOut}" = "${MAC_OS}" ]
-    echo "I AM IN THE CASE"
+    requestedDate="${1}"
+    if [ "${requestedDate}" = "${MAC_OS}" ]
     then
-        case "${arg}" in
+        case "${c}" in
         "tomorrow")
             generatedDate="$(date -j -v+1d +${defaultDateFormat})"
             ;;
@@ -56,9 +54,9 @@ generateDate() {
             generatedDate="$(date -j +${defaultDateFormat})"
             ;;
         esac
-    elif [ "${1}" = "${LINUX_OS}" ]
+    elif [ "${requestedDate}" = "${LINUX_OS}" ]
     then
-        case "${arg}" in
+        case "${https://www.youtube.com/watch?v=qhN0tzN9zTA}" in
         "tomorrow")
             generatedDate="$( date --date="tomorrow" +${defaultDateFormat} )"
             ;;

--- a/note-begin
+++ b/note-begin
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-source ./date-parser "today"
-
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${initialLocation}/date-parser" $1
 
 . ${initialLocation}/note-sync
 

--- a/note-begin
+++ b/note-begin
@@ -5,8 +5,8 @@ source "${rootFolder}/date-parser"
 
 . ${rootFolder}/note-sync
 
-# generateDate (function) and generatedDate (variable) are sourced from date-parser
-generateDate $1
-document_date="${1:-${generatedDate}}"
+# generateDate (function) is sourced from date-parser
+generatedDate="$(generateDate $1)"
+documentDate="${1:-${generatedDate}}"
 
-. ${rootFolder}/note-new "${document_date}"
+. ${rootFolder}/note-new "${documentDate}"

--- a/note-begin
+++ b/note-begin
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+source ./date-parser "today"
+
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 . ${initialLocation}/note-sync
 
-document_date="${1:-today}"
+# generateDate (function) and generatedDate (variable) are sourced from date-parser
+generateDate
+document_date="${1:-${generatedDate}}"
 
 . ${initialLocation}/note-new "${document_date}"

--- a/note-begin
+++ b/note-begin
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "${initialLocation}/date-parser"
+rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${rootFolder}/date-parser"
 
-. ${initialLocation}/note-sync
+. ${rootFolder}/note-sync
 
 # generateDate (function) and generatedDate (variable) are sourced from date-parser
 generateDate $1
 document_date="${1:-${generatedDate}}"
 
-. ${initialLocation}/note-new "${document_date}"
+. ${rootFolder}/note-new "${document_date}"

--- a/note-begin
+++ b/note-begin
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "${initialLocation}/date-parser" $1
+source "${initialLocation}/date-parser"
 
 . ${initialLocation}/note-sync
 
 # generateDate (function) and generatedDate (variable) are sourced from date-parser
-generateDate
+generateDate $1
 document_date="${1:-${generatedDate}}"
 
 . ${initialLocation}/note-new "${document_date}"

--- a/note-end
+++ b/note-end
@@ -24,10 +24,9 @@ if [[ ! -z $sections ]]; then
   done
 fi
 
-# parseInputDate (function) and formattedDate (variable) are sourced from date-parser
-parseInputDate $1
+# parseInputDate (function) is sourced from date-parser
+formattedDate="$(parseInputDate $1)"
 git add "${filePath}" && git commit -F "${filePath}" && git tag "${formattedDate}"
-
 
 git push origin master
 

--- a/note-end
+++ b/note-end
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source ./date-parser $1
-
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rootFolder="$(cat "${initialLocation}/.noteFolderPath")"
 if [ -z $rootFolder ]; then
@@ -10,6 +8,7 @@ if [ -z $rootFolder ]; then
 fi
 
 # parseInputDate (function) and formattedDate (variable) are sourced from date-parser
+source "${rootFolder}/date-parser" $1
 parseInputDate
 
 noteFolderLocation="${rootFolder}/notes"

--- a/note-end
+++ b/note-end
@@ -1,20 +1,18 @@
 #!/bin/bash
 
-initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-rootFolder="$(cat "${initialLocation}/.noteFolderPath")"
-if [ -z $rootFolder ]; then
+appRootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${appRootFolder}/date-parser"
+
+notesRootFolder="$(cat "${appRootFolder}/.noteFolderPath")"
+if [ -z $notesRootFolder ]; then
   echo "Can't find root folder, did you run note-setup?"
   exit 1
 fi
 
-# parseInputDate (function) and formattedDate (variable) are sourced from date-parser
-source "${rootFolder}/date-parser" $1
-parseInputDate
-
-noteFolderLocation="${rootFolder}/notes"
+noteFolderLocation="${notesRootFolder}/notes"
 filePath="${noteFolderLocation}/${formattedDate}.md"
 
-cd "${rootFolder}"
+cd "${notesRootFolder}"
 
 sections=$(cat "${rootFolder}/.sections")
 
@@ -26,9 +24,11 @@ if [[ ! -z $sections ]]; then
   done
 fi
 
+# parseInputDate (function) and formattedDate (variable) are sourced from date-parser
+parseInputDate $1
 git add "${filePath}" && git commit -F "${filePath}" && git tag "${formattedDate}"
 
 
 git push origin master
 
-cd "${initialLocation}"
+cd "${appRootFolder}"

--- a/note-end
+++ b/note-end
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-appRootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "${appRootFolder}/date-parser"
+rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${rootFolder}/date-parser"
 
-notesRootFolder="$(cat "${appRootFolder}/.noteFolderPath")"
-if [ -z $notesRootFolder ]; then
+notesFolder="$(cat "${rootFolder}/.noteFolderPath")"
+if [ -z $notesFolder ]; then
   echo "Can't find root folder, did you run note-setup?"
   exit 1
 fi
 
-noteFolderLocation="${notesRootFolder}/notes"
+noteFolderLocation="${notesFolder}/notes"
 filePath="${noteFolderLocation}/${formattedDate}.md"
 
-cd "${notesRootFolder}"
+cd "${notesFolder}"
 
 sections=$(cat "${rootFolder}/.sections")
 
@@ -31,4 +31,4 @@ git add "${filePath}" && git commit -F "${filePath}" && git tag "${formattedDate
 
 git push origin master
 
-cd "${appRootFolder}"
+cd "${rootFolder}"

--- a/note-end
+++ b/note-end
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-required_date="${1:-today}"
+source ./date-parser $1
 
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rootFolder="$(cat "${initialLocation}/.noteFolderPath")"
@@ -9,10 +9,11 @@ if [ -z $rootFolder ]; then
   exit 1
 fi
 
-formated_date="$( date -d "${required_date}" +'%Y-%m-%d' )"
-noteFolderLocation="${rootFolder}/notes"
-filePath="${noteFolderLocation}/${formated_date}.md"
+# parseInputDate (function) and formattedDate (variable) are sourced from date-parser
+parseInputDate
 
+noteFolderLocation="${rootFolder}/notes"
+filePath="${noteFolderLocation}/${formattedDate}.md"
 
 cd "${rootFolder}"
 
@@ -26,7 +27,7 @@ if [[ ! -z $sections ]]; then
   done
 fi
 
-git add "${filePath}" && git commit -F "${filePath}" && git tag "${formated_date}"
+git add "${filePath}" && git commit -F "${filePath}" && git tag "${formattedDate}"
 
 
 git push origin master

--- a/note-folder
+++ b/note-folder
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-required_date="${1:-today}"
-
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rootFolder="$( cat "${rootFolder}/.noteFolderPath")"
 if [ ! -z $rootFolder ]; then

--- a/note-folder
+++ b/note-folder
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-rootFolder="$( cat "${rootFolder}/.noteFolderPath")"
-if [ ! -z $rootFolder ]; then
-    echo "${rootFolder}"
+notesFolder="$( cat "${rootFolder}/.noteFolderPath")"
+if [ ! -z "${notesFolder}" ]; then
+    echo "${notesFolder}"
 fi
 

--- a/note-new
+++ b/note-new
@@ -12,7 +12,7 @@ noteFolderLocation="${notesFolder}/notes"
 
 # parseInputDate (function) and formattedDate (variable) are sourced from date-parser
 source "${rootFolder}/date-parser"
-parseInputDate $1
+formattedDate="$(parseInputDate $1)"
 filePath="${noteFolderLocation}/${formattedDate}.md"
 
 if [ ! -e $filePath	]

--- a/note-new
+++ b/note-new
@@ -1,22 +1,6 @@
 #!/bin/bash
 
-# Used to check which machine we are running on
-unameOut="$(uname -s)"
-MAC_OS="Darwin"
-LINUX_OS="Linux"
-
-# Use date from args, or default, take into account date implementation differences
-if [ "${unameOut}" = "${LINUX_OS}" ]
-then
-  requiredDate="${1:-today}"
-elif [ "${unameOut}" = "${MAC_OS}" ]
-then
-  # On BSD based systems (i.e. Mac), date cannot accept any input as a string
-  # So we have to enforce a specific format to validate against
-  macOsDefaultDateFormat="%Y-%m-%d"
-  todaysDateMacOs="$(date -j +${macOsDefaultDateFormat})"
-  requiredDate="${1:-todaysDateMacOs}"
-fi
+source ./date-parser $1
 
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rootFolder="$( cat "${rootFolder}/.noteFolderPath")"
@@ -26,25 +10,10 @@ if [ -z $rootFolder ]; then
   exit 1
 fi
 
-# Validate input date and format it
-# Take into account different implementations of `date` commant
-elif [ "${unameOut}" = "${LINUX_OS}" ]
-then
-  formated_date="$( date -d "${requiredDate}" +'%Y-%m-%d' )"
-elif [ "${unameOut}" = "${MAC_OS}" ]
-then
-  validation_result="$(date -j -f ${macOsDefaultDateFormat} -j ${requiredDate} > /dev/null 2>&1)"
-  if [ "$?" = "1" ]
-  then
-    echo "Invalid date format for ${requiredDate}, expected ${macOsDefaultDateFormat}"
-    exit 1
-  fi
-  formated_date="$( date -j -f "${requiredDate}" +'%Y-%m-%d' )"
-fi
-
 noteFolderLocation="${rootFolder}/notes"
-
-filePath="${noteFolderLocation}/${formated_date}.md"
+# parseInputDate (function) and formattedDate (variable) are sourced from date-parser
+parseInputDate
+filePath="${noteFolderLocation}/${formattedDate}.md"
 
 if [ ! -d "${noteFolderLocation}"	]
 then

--- a/note-new
+++ b/note-new
@@ -1,15 +1,47 @@
 #!/bin/bash
 
-required_date="${1:-today}"
+# Used to check which machine we are running on
+unameOut="$(uname -s)"
+MAC_OS="Darwin"
+LINUX_OS="Linux"
+
+# Use date from args, or default, take into account date implementation differences
+if [ "${unameOut}" = "${LINUX_OS}" ]
+then
+  requiredDate="${1:-today}"
+elif [ "${unameOut}" = "${MAC_OS}" ]
+then
+  # On BSD based systems (i.e. Mac), date cannot accept any input as a string
+  # So we have to enforce a specific format to validate against
+  macOsDefaultDateFormat="%Y-%m-%d"
+  todaysDateMacOs="$(date -j +${macOsDefaultDateFormat})"
+  requiredDate="${1:-todaysDateMacOs}"
+fi
 
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rootFolder="$( cat "${rootFolder}/.noteFolderPath")"
+
 if [ -z $rootFolder ]; then
   echo "Can't find root folder '${rootFolder}', did you run note-setup?"
   exit 1
 fi
 
-formated_date="$( date -d "${required_date}" +'%Y-%m-%d' )"
+# Validate input date and format it
+# Take into account different implementations of `date` commant
+elif [ "${unameOut}" = "${LINUX_OS}" ]
+then
+  formated_date="$( date -d "${requiredDate}" +'%Y-%m-%d' )"
+elif [ "${unameOut}" = "${MAC_OS}" ]
+then
+  validation_result="$(date -j -f ${macOsDefaultDateFormat} -j ${requiredDate} > /dev/null 2>&1)"
+  if [ "$?" = "1" ]
+  then
+    echo "Invalid date format for ${requiredDate}, expected ${macOsDefaultDateFormat}"
+    exit 1
+  fi
+  formated_date="$( date -j -f "${requiredDate}" +'%Y-%m-%d' )"
+fi
+
 noteFolderLocation="${rootFolder}/notes"
 
 filePath="${noteFolderLocation}/${formated_date}.md"

--- a/note-new
+++ b/note-new
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source ./date-parser $1
-
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rootFolder="$( cat "${rootFolder}/.noteFolderPath")"
 
@@ -11,7 +9,9 @@ if [ -z $rootFolder ]; then
 fi
 
 noteFolderLocation="${rootFolder}/notes"
+
 # parseInputDate (function) and formattedDate (variable) are sourced from date-parser
+source "${rootFolder}/date-parser" $1
 parseInputDate
 filePath="${noteFolderLocation}/${formattedDate}.md"
 

--- a/note-new
+++ b/note-new
@@ -10,7 +10,7 @@ fi
 
 noteFolderLocation="${notesFolder}/notes"
 
-# parseInputDate (function) and formattedDate (variable) are sourced from date-parser
+# parseInputDate is sourced from date-parser
 source "${rootFolder}/date-parser"
 formattedDate="$(parseInputDate $1)"
 filePath="${noteFolderLocation}/${formattedDate}.md"

--- a/note-new
+++ b/note-new
@@ -1,38 +1,32 @@
 #!/bin/bash
 
-rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-rootFolder="$( cat "${rootFolder}/.noteFolderPath")"
+appRootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+notesRootFolder="$( cat "${appRootFolder}/.noteFolderPath")"
 
-if [ -z $rootFolder ]; then
-  echo "Can't find root folder '${rootFolder}', did you run note-setup?"
+if [ -z $notesRootFolder ]; then
+  echo "Can't find root folder '${notesRootFolder}', did you run note-setup?"
   exit 1
 fi
 
-noteFolderLocation="${rootFolder}/notes"
+noteFolderLocation="${notesRootFolder}/notes"
 
 # parseInputDate (function) and formattedDate (variable) are sourced from date-parser
-source "${rootFolder}/date-parser" $1
-parseInputDate
+source "${appRootFolder}/date-parser"
+parseInputDate $1
 filePath="${noteFolderLocation}/${formattedDate}.md"
-
-if [ ! -d "${noteFolderLocation}"	]
-then
-	mkdir -p "${noteFolderLocation}"
-fi
 
 if [ ! -e $filePath	]
 then
     # Create today's file based on template
-    cp "${rootFolder}/.template.md" "${filePath}"
+    cp "${appRootFolder}/.template.md" "${filePath}"
 
     echo "Applying sections to ${filePath}:"
-    for section in $(ls -a "${rootFolder}" | grep .section.); do
+    for section in $(ls -a "${appRootFolder}" | grep .section.); do
       echo "* ${section}"
-      cat "${rootFolder}/${section}" >> "${filePath}"
-      rm "${rootFolder}/${section}"
+      cat "${appRootFolder}/${section}" >> "${filePath}"
+      rm "${appRootFolder}/${section}"
     done
 fi
-
 
 echo "Editing file ${filePath}"
 $EDITOR "${filePath}"

--- a/note-new
+++ b/note-new
@@ -1,30 +1,30 @@
 #!/bin/bash
 
-appRootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-notesRootFolder="$( cat "${appRootFolder}/.noteFolderPath")"
+rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+notesFolder="$( cat "${rootFolder}/.noteFolderPath")"
 
-if [ -z $notesRootFolder ]; then
-  echo "Can't find root folder '${notesRootFolder}', did you run note-setup?"
+if [ -z $notesFolder ]; then
+  echo "Can't find root folder '${notesFolder}', did you run note-setup?"
   exit 1
 fi
 
-noteFolderLocation="${notesRootFolder}/notes"
+noteFolderLocation="${notesFolder}/notes"
 
 # parseInputDate (function) and formattedDate (variable) are sourced from date-parser
-source "${appRootFolder}/date-parser"
+source "${rootFolder}/date-parser"
 parseInputDate $1
 filePath="${noteFolderLocation}/${formattedDate}.md"
 
 if [ ! -e $filePath	]
 then
     # Create today's file based on template
-    cp "${appRootFolder}/.template.md" "${filePath}"
+    cp "${rootFolder}/.template.md" "${filePath}"
 
     echo "Applying sections to ${filePath}:"
-    for section in $(ls -a "${appRootFolder}" | grep .section.); do
+    for section in $(ls -a "${rootFolder}" | grep .section.); do
       echo "* ${section}"
-      cat "${appRootFolder}/${section}" >> "${filePath}"
-      rm "${appRootFolder}/${section}"
+      cat "${rootFolder}/${section}" >> "${filePath}"
+      rm "${rootFolder}/${section}"
     done
 fi
 

--- a/note-open
+++ b/note-open
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source ./date-parser $1
-
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rootFolder="$( cat "${rootFolder}/.noteFolderPath")"
 if [ -z $rootFolder ]; then
@@ -10,6 +8,7 @@ if [ -z $rootFolder ]; then
 fi
 
 # parseInputDate (function) and formattedDate (variable) are sourced from date-parser
+source "${rootFolder}/date-parser" $1
 parseInputDate
 noteFolderLocation="${rootFolder}/notes"
 filePath="${noteFolderLocation}/${formattedDate}.md"

--- a/note-open
+++ b/note-open
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-required_date="${1:-today}"
+source ./date-parser $1
 
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rootFolder="$( cat "${rootFolder}/.noteFolderPath")"
@@ -9,17 +9,15 @@ if [ -z $rootFolder ]; then
   exit 1
 fi
 
-formated_date="$( date -d "${required_date}" +'%Y-%m-%d' )"
+# parseInputDate (function) and formattedDate (variable) are sourced from date-parser
+parseInputDate
 noteFolderLocation="${rootFolder}/notes"
-
-filePath="${noteFolderLocation}/${formated_date}.md"
-
+filePath="${noteFolderLocation}/${formattedDate}.md"
 
 if [ ! -d "${noteFolderLocation}"	]
 then
 	mkdir -p "${noteFolderLocation}"
 fi
-
 
 if [ ! -e $filePath	]
 then

--- a/note-open
+++ b/note-open
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-rootFolder="$( cat "${rootFolder}/.noteFolderPath")"
-if [ -z $rootFolder ]; then
+appRootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${appRootFolder}/date-parser"
+
+notesRootFolder="$( cat "${appRootFolder}/.noteFolderPath")"
+if [ -z $notesRootFolder ]; then
   echo "Can't find root folder, did you run note-setup?"
   exit 1
 fi
 
 # parseInputDate (function) and formattedDate (variable) are sourced from date-parser
-source "${rootFolder}/date-parser" $1
-parseInputDate
-noteFolderLocation="${rootFolder}/notes"
+parseInputDate $1
+noteFolderLocation="${notesRootFolder}/notes"
 filePath="${noteFolderLocation}/${formattedDate}.md"
 
 if [ ! -d "${noteFolderLocation}"	]

--- a/note-open
+++ b/note-open
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-appRootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "${appRootFolder}/date-parser"
+rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${rootFolder}/date-parser"
 
-notesRootFolder="$( cat "${appRootFolder}/.noteFolderPath")"
-if [ -z $notesRootFolder ]; then
+notesFolder="$( cat "${rootFolder}/.noteFolderPath")"
+if [ -z $notesFolder ]; then
   echo "Can't find root folder, did you run note-setup?"
   exit 1
 fi
 
 # parseInputDate (function) and formattedDate (variable) are sourced from date-parser
 parseInputDate $1
-noteFolderLocation="${notesRootFolder}/notes"
+noteFolderLocation="${notesFolder}/notes"
 filePath="${noteFolderLocation}/${formattedDate}.md"
 
 if [ ! -d "${noteFolderLocation}"	]

--- a/note-open
+++ b/note-open
@@ -9,8 +9,8 @@ if [ -z $notesFolder ]; then
   exit 1
 fi
 
-# parseInputDate (function) and formattedDate (variable) are sourced from date-parser
-parseInputDate $1
+# parseInputDate (function) is sourced from date-parser
+formattedDate="$(parseInputDate $1)"
 noteFolderLocation="${notesFolder}/notes"
 filePath="${noteFolderLocation}/${formattedDate}.md"
 

--- a/note-setup
+++ b/note-setup
@@ -45,10 +45,10 @@ then
   exit 1
 fi
 
-if [ ! -d "${noteFolder}"	]
+if [ ! -d "${noteFolder}/notes"	]
 then
-  echo "Folder '${noteFolder}' does not exist"
-  exit 1
+  echo "Folder '${noteFolder}' does not exist, creating..."
+  mkdir -p "${noteFolder}/notes"
 fi
 
 # Save note folder location

--- a/note-sync
+++ b/note-sync
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-notesFolderPath="$( cat "${initialLocation}/.noteFolderPath")"
-if [ -z $notesFolderPath ]; then
-  echo "Can't find root folder ${notesFolderPath}'', did you run note-setup?"
+rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+notesFolder="$( cat "${rootFolder}/.noteFolderPath")"
+if [ -z $notesFolder ]; then
+  echo "Can't find root folder ${notesFolder}'', did you run note-setup?"
   exit 1
 fi
 
-cd "${notesFolderPath}"
+cd "${notesFolder}"
 git fetch origin && git rebase origin/master
-cd "${initialLocation}"
+cd "${rootFolder}"

--- a/note-sync
+++ b/note-sync
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-rootFolder="$( cat "${initialLocation}/.noteFolderPath")"
-if [ -z $rootFolder ]; then
-  echo "Can't find root folder ${rootFolder}'', did you run note-setup?"
+notesFolderPath="$( cat "${initialLocation}/.noteFolderPath")"
+if [ -z $notesFolderPath ]; then
+  echo "Can't find root folder ${notesFolderPath}'', did you run note-setup?"
   exit 1
 fi
 
-cd "${rootFolder}"
+cd "${notesFolderPath}"
 git fetch origin && git rebase origin/master
 cd "${initialLocation}"

--- a/note-tomorrow
+++ b/note-tomorrow
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "${initialLocation}/date-parser"
+rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${rootFolder}/date-parser"
 
 # generateDate (function) and generatedDate (variable) are sourced from date-parser
 generateDate "tomorrow"
 document_date="${1:-${generatedDate}}"
 
-. "${initialLocation}/note-sync"
+. "${rootFolder}/note-sync"
 
-. "${initialLocation}/note-open" "${document_date}"
+. "${rootFolder}/note-open" "${document_date}"

--- a/note-tomorrow
+++ b/note-tomorrow
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "${initialLocation}/date-parser" "tomorrow"
+source "${initialLocation}/date-parser"
 
 # generateDate (function) and generatedDate (variable) are sourced from date-parser
-generateDate
+generateDate "tomorrow"
 document_date="${1:-${generatedDate}}"
 
 . "${initialLocation}/note-sync"

--- a/note-tomorrow
+++ b/note-tomorrow
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-source ./date-parser "tomorrow"
-
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
+source "${initialLocation}/date-parser" "tomorrow"
 
 # generateDate (function) and generatedDate (variable) are sourced from date-parser
 generateDate

--- a/note-tomorrow
+++ b/note-tomorrow
@@ -3,10 +3,10 @@
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${rootFolder}/date-parser"
 
-# generateDate (function) and generatedDate (variable) are sourced from date-parser
-generateDate "tomorrow"
-document_date="${1:-${generatedDate}}"
+# generateDate (function) is sourced from date-parser
+generatedDate="$(generateDate $1)"
+documentDate="${1:-${generatedDate}}"
 
 . "${rootFolder}/note-sync"
 
-. "${rootFolder}/note-open" "${document_date}"
+. "${rootFolder}/note-open" "${documentDate}"

--- a/note-tomorrow
+++ b/note-tomorrow
@@ -1,8 +1,13 @@
 #!/bin/bash
 
+source ./date-parser "tomorrow"
+
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-document_date="${1:-tomorrow}"
+
+# generateDate (function) and generatedDate (variable) are sourced from date-parser
+generateDate
+document_date="${1:-${generatedDate}}"
 
 . "${initialLocation}/note-sync"
 

--- a/note-yesterday
+++ b/note-yesterday
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "${initialLocation}/date-parser" "yesterday"
+source "${initialLocation}/date-parser"
 
 # generateDate (function) and generatedDate (variable) are sourced from date-parser
-generateDate
+generateDate "yesterday"
 document_date="${1:-${generatedDate}}"
 
 . "${initialLocation}/note-sync"

--- a/note-yesterday
+++ b/note-yesterday
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+source ./date-parser "yesterday"
+
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-document_date="$( date --date="yesterday" +'%Y-%m-%d' )"
+# generateDate (function) and generatedDate (variable) are sourced from date-parser
+generateDate
+document_date="${1:-${generatedDate}}"
 
 . "${initialLocation}/note-sync"
 

--- a/note-yesterday
+++ b/note-yesterday
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source "${initialLocation}/date-parser"
+rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${rootFolder}/date-parser"
 
 # generateDate (function) and generatedDate (variable) are sourced from date-parser
 generateDate "yesterday"
 document_date="${1:-${generatedDate}}"
 
-. "${initialLocation}/note-sync"
+. "${rootFolder}/note-sync"
 
-. "${initialLocation}/note-open" "${document_date}"
+. "${rootFolder}/note-open" "${document_date}"

--- a/note-yesterday
+++ b/note-yesterday
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-source ./date-parser "yesterday"
-
 initialLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${initialLocation}/date-parser" "yesterday"
 
 # generateDate (function) and generatedDate (variable) are sourced from date-parser
 generateDate

--- a/note-yesterday
+++ b/note-yesterday
@@ -3,10 +3,10 @@
 rootFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${rootFolder}/date-parser"
 
-# generateDate (function) and generatedDate (variable) are sourced from date-parser
-generateDate "yesterday"
-document_date="${1:-${generatedDate}}"
+# generateDate (function) is sourced from date-parser
+generatedDate="$(generateDate $1)"
+documentDate="${1:-${generatedDate}}"
 
 . "${rootFolder}/note-sync"
 
-. "${rootFolder}/note-open" "${document_date}"
+. "${rootFolder}/note-open" "${documentDate}"


### PR DESCRIPTION
I did the changes on a single file to get your pulse on the implementation method.
The main goal here is to add support for mac os, which has a different implementation of the `date` command. Here is a summary of my changes:

- Added automated check to determine if we are on Linux or Mac (uname -s)
- Add default date format for mac
- Add validation when the date is user specified and on a Mac, unfortunately the `date` command does not accept any string, the date will have to have a minimum formatting
- Add error message when the date is invalid