### PR TITLE
Small typo when checking what date util to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Low tech note taking ~application~ scripts
 ### Requirements:
 Should work on most "standard" linux distro
 * `git`
-* `gnu date`
+* `gnu date` (For MacOS, get gnudate via `brew install coreutils`)
 * `awk`
 * A text editor (`EDITOR` environment variable need to be set)
 * `bash` or `zsh` for autocompletion

--- a/scripts/gnudate.sh
+++ b/scripts/gnudate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 gnudate() {
-    if commant -v gdate &> /dev/null; then
+    if command -v gdate &> /dev/null; then
         gdate "$@"
     else
         date "$@"


### PR DESCRIPTION
## Summary

- Fix typo in date util to enable checking the shell utility used to manage dates
- Add a MacOS specific instruction on how to get `gnudate` in the readme

## Detailed description

Fix a small typo in the gnudate.sh util commant -> command

Problem description: This typo caused the date checking not to happen, resulting in dateless journal files being created when calling the `journal begin` command on MacOs.

Before the change:

```
 sbeaulieu  ~  journal begin
[...] // CLI output deleted for example purposes
Editing file /Users/sbeaulieu/.my-notes/journal/.md
```

After the change:

```
 sbeaulieu   master  ~/.bin/daily-notes  journal begin
[...] // CLI output deleted for example purposes
Editing file /Users/sbeaulieu/.my-notes/journal/2021-02-08.md
```